### PR TITLE
remove unused href and add classes

### DIFF
--- a/bootstrap/app/views/kaminari/_gap.html.erb
+++ b/bootstrap/app/views/kaminari/_gap.html.erb
@@ -1,3 +1,3 @@
-<li class="disabled">
-  <%= link_to raw(t 'views.pagination.truncate'), '#' %>
+<li class="page gap disabled">
+  <a><%= raw(t 'views.pagination.truncate') %></a>
 </li>

--- a/bootstrap/app/views/kaminari/_gap.html.haml
+++ b/bootstrap/app/views/kaminari/_gap.html.haml
@@ -1,2 +1,2 @@
-%li.disabled
-  = link_to raw(t 'views.pagination.truncate'), '#'
+%li.page.gap.disabled
+  %a= raw(t 'views.pagination.truncate')


### PR DESCRIPTION
In bootstrap theme, href attributes are unnecessary.
And page and gap classes are missing.
