### PR TITLE
remove unused class attribute in bootstrap page partials

### DIFF
--- a/bootstrap/app/views/kaminari/_page.html.erb
+++ b/bootstrap/app/views/kaminari/_page.html.erb
@@ -1,3 +1,3 @@
-<li class="<%= 'active' if page.current? %>">
+<li <%= "class=active" if page.current? -%>>
   <%= link_to page, page.current? ? '#' : url, {:remote => remote, :rel => page.next? ? 'next' : page.prev? ? 'prev' : nil} %>
 </li>

--- a/bootstrap/app/views/kaminari/_page.html.haml
+++ b/bootstrap/app/views/kaminari/_page.html.haml
@@ -1,2 +1,2 @@
-%li{class: "#{'active' if page.current?}"}
+%li{page.current? ? {:class => 'active'} : {} }
   = link_to page, page.current? ? '#' : url, {:remote => remote, :rel => page.next? ? 'next' : page.prev? ? 'prev' : nil}


### PR DESCRIPTION
li elements contain an empty class attribute. Although it's
valid html, it's unnecessary, and markup should be minimal.

This pull request fixes issue #15.
