### PR TITLE
remove unused href attribute on gap partial

### DIFF
--- a/bootstrap/app/views/kaminari/_gap.html.erb
+++ b/bootstrap/app/views/kaminari/_gap.html.erb
@@ -1,3 +1,1 @@
-<li class="disabled">
-  <%= link_to raw(t 'views.pagination.truncate'), '#' %>
-</li>
+<%= content_tag :li, content_tag( :a, raw(t 'views.pagination.truncate')), class: :disabled %>

--- a/bootstrap/app/views/kaminari/_gap.html.haml
+++ b/bootstrap/app/views/kaminari/_gap.html.haml
@@ -1,2 +1,2 @@
 %li.disabled
-  = link_to raw(t 'views.pagination.truncate'), '#'
+  = content_tag :a, raw(t 'views.pagination.truncate')


### PR DESCRIPTION
I exchanged link_to's for content_tag :a's in order to remove the href.
This is related to @znz's request to [remove unused href and add classes](https://github.com/amatsuda/kaminari_themes/pull/12) in [issue #12](https://github.com/amatsuda/kaminari_themes/pull/12)
