### PR TITLE
Update Kaminari Page template for purecss.io

### DIFF
--- a/purecss/app/views/kaminari/_page.html.erb
+++ b/purecss/app/views/kaminari/_page.html.erb
@@ -1,3 +1,3 @@
-<li class="pure-button<%= ' pure-button-active' if page.current? %>">
-  <%= link_to page, url, {:remote => remote, :rel => page.next? ? 'next' : page.prev? ? 'prev' : nil} %>
+<li>
+  <%= link_to page, url, {:class => "pure-button#{' pure-button-active' if page.current?}", :remote => remote, :rel => page.next? ? 'next' : page.prev? ? 'prev' : nil} %>
 </li>

--- a/purecss/app/views/kaminari/_page.html.haml
+++ b/purecss/app/views/kaminari/_page.html.haml
@@ -1,2 +1,2 @@
-%li{:class => "pure-button#{' pure-button-active' if page.current?}"}
-  = link_to page, url, {:remote => remote, :rel => page.next? ? 'next' : page.prev? ? 'prev' : nil}
+%li
+  = link_to page, url, {:class => "pure-button#{' pure-button-active' if page.current?}", :remote => remote, :rel => page.next? ? 'next' : page.prev? ? 'prev' : nil}

--- a/purecss/app/views/kaminari/_page.html.slim
+++ b/purecss/app/views/kaminari/_page.html.slim
@@ -1,2 +1,2 @@
-li class=("pure-button#{' pure-button-active' if page.current?}") 
-  = link_to page, url, {:remote => remote, :rel => page.next? ? 'next' : page.prev? ? 'prev' : nil}
+li
+  = link_to page, url, {:class => "pure-button#{' pure-button-active' if page.current?}", :remote => remote, :rel => page.next? ? 'next' : page.prev? ? 'prev' : nil}


### PR DESCRIPTION
Pure CSS example on the web requires the link to have the pure-button
CSS class and not the LI. The affects UX negatively at the moment
because the link has a very small hit area.
