### PR TITLE
Update _paginator.html.slim

### DIFF
--- a/foundation/app/views/kaminari/_paginator.html.slim
+++ b/foundation/app/views/kaminari/_paginator.html.slim
@@ -1,12 +1,12 @@
 = paginator.render do
   .pagination-centered
     ul.pagination
-      = first_page_tag unless current_page.first?
-      = prev_page_tag unless current_page.first?
+      == first_page_tag unless current_page.first?
+      == prev_page_tag unless current_page.first?
       - each_page do |page|
         - if page.left_outer? || page.right_outer? || page.inside_window?
-          = page_tag page
+          == page_tag page
         - elsif !page.was_truncated?
-          = gap_tag
-      = next_page_tag unless current_page.last?
-      = last_page_tag unless current_page.last?
+          == gap_tag
+      == next_page_tag unless current_page.last?
+      == last_page_tag unless current_page.last?


### PR DESCRIPTION
fix wrong rendering pagination in production mode for slim:

When I use foundation template in production mode pagination rendered as text, i.e. sanitized html