### PR TITLE
Bourbon Theme: Fixed _gap.erb (it was a copy of _prev_page.erb)

### DIFF
--- a/bourbon/app/views/kaminari/_gap.erb
+++ b/bourbon/app/views/kaminari/_gap.erb
@@ -1,3 +1,3 @@
-<li class="page-prev">
-  <%= link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, :rel => 'prev', :remote => remote %>
+<li>
+  <%= t('views.pagination.truncate').html_safe %>
 </li>


### PR DESCRIPTION
Just found out that `_gap.erb` was actually a copy of `_prev_page.erb`.

This new version is based on `_gap.html.haml`, so it should be ok now.