### PR TITLE
Fixed _paginator.html.slim

### DIFF
--- a/bootstrap4/app/views/kaminari/_paginator.html.slim
+++ b/bootstrap4/app/views/kaminari/_paginator.html.slim
@@ -1,10 +1,10 @@
 = paginator.render do
   nav
     ul.pagination
-      = first_page_tag unless current_page.first?
-      = prev_page_tag unless current_page.first?
+      == first_page_tag unless current_page.first?
+      == prev_page_tag unless current_page.first?
       - each_page do |page|
         - if page.left_outer? || page.right_outer? || page.inside_window?
-          = page_tag page
-      = next_page_tag unless current_page.last?
-      = last_page_tag unless current_page.last?
+          == page_tag page
+      == next_page_tag unless current_page.last?
+      == last_page_tag unless current_page.last?


### PR DESCRIPTION
`=` makes HTML.
`==` makes raw HTML.(This is correct.)

It is same bootstrap3 https://github.com/amatsuda/kaminari_themes/blob/master/bootstrap3/app/views/kaminari/_paginator.html.slim