### PR TITLE
HTML safe slim output

### DIFF
--- a/materialize/app/views/kaminari/_paginator.html.slim
+++ b/materialize/app/views/kaminari/_paginator.html.slim
@@ -1,9 +1,9 @@
 = paginator.render do
   ul.pagination
-    = prev_page_tag
+    == prev_page_tag
     - each_page do |page|
       - if page.left_outer? || page.right_outer? || page.inside_window?
-        = page_tag page
+        == page_tag page
       - elsif !page.was_truncated?
-        = gap_tag
-    = next_page_tag
+        == gap_tag
+    == next_page_tag


### PR DESCRIPTION
Before when doing `= paginate collection` it would correctly render the wrapping `ul`, but display nested `li`s as a string, not actual html tags.