### PR TITLE
unify bootstrap3 view template notation

### DIFF
--- a/bootstrap3/app/views/kaminari/_last_page.html.erb
+++ b/bootstrap3/app/views/kaminari/_last_page.html.erb
@@ -1,3 +1,3 @@
 <li>
-  <%= link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, {:remote => remote} %>
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, :remote => remote %>
 </li>

--- a/bootstrap3/app/views/kaminari/_last_page.html.haml
+++ b/bootstrap3/app/views/kaminari/_last_page.html.haml
@@ -1,2 +1,2 @@
 %li
-  = link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, {:remote => remote}
+  = link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, :remote => remote


### PR DESCRIPTION
## overviews
create views by following command `rails g kaminari:views bootstrap3`
then create 2 kind of notation view files.

thus unify bootstrap3 view template notation.

## changes
delete 4th argument braces of link_to_unless method in following views.

- _last_page.html.erb
- _last_page.html.haml