### PR TITLE
Bootstrap3 - Remove hash rockets

### DIFF
--- a/bootstrap3/app/views/kaminari/_first_page.html.erb
+++ b/bootstrap3/app/views/kaminari/_first_page.html.erb
@@ -1,3 +1,3 @@
 <li>
-  <%= link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, :remote => remote %>
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, remote: remote %>
 </li>

--- a/bootstrap3/app/views/kaminari/_first_page.html.haml
+++ b/bootstrap3/app/views/kaminari/_first_page.html.haml
@@ -1,2 +1,2 @@
 %li
-  = link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, :remote => remote
+  = link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, remote: remote

--- a/bootstrap3/app/views/kaminari/_last_page.html.erb
+++ b/bootstrap3/app/views/kaminari/_last_page.html.erb
@@ -1,3 +1,3 @@
 <li>
-  <%= link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, {:remote => remote} %>
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, { remote: remote } %>
 </li>

--- a/bootstrap3/app/views/kaminari/_last_page.html.haml
+++ b/bootstrap3/app/views/kaminari/_last_page.html.haml
@@ -1,2 +1,2 @@
 %li
-  = link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, {:remote => remote}
+  = link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, { remote: remote }

--- a/bootstrap3/app/views/kaminari/_next_page.html.erb
+++ b/bootstrap3/app/views/kaminari/_next_page.html.erb
@@ -1,3 +1,3 @@
 <li>
-  <%= link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, :rel => 'next', :remote => remote %>
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, rel: 'next', remote: remote %>
 </li>

--- a/bootstrap3/app/views/kaminari/_next_page.html.haml
+++ b/bootstrap3/app/views/kaminari/_next_page.html.haml
@@ -1,2 +1,2 @@
 %li
-  = link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, :rel => 'next', :remote => remote
+  = link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, rel: 'next', remote: remote

--- a/bootstrap3/app/views/kaminari/_prev_page.html.erb
+++ b/bootstrap3/app/views/kaminari/_prev_page.html.erb
@@ -1,3 +1,3 @@
 <li>
-  <%= link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, :rel => 'prev', :remote => remote %>
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, rel: 'prev', remote: remote %>
 </li>

--- a/bootstrap3/app/views/kaminari/_prev_page.html.haml
+++ b/bootstrap3/app/views/kaminari/_prev_page.html.haml
@@ -1,2 +1,2 @@
 %li
-  = link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, :rel => 'prev', :remote => remote
+  = link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, rel: 'prev', remote: remote


### PR DESCRIPTION
There was a mixture of 1.8 and 1.9 style hashes in here, so I converted all to 1.9 style.