### PR TITLE
Wrap remote attr in content tag with data hash for bootstrap themes

### DIFF
--- a/bootstrap2/app/views/kaminari/_page.html.erb
+++ b/bootstrap2/app/views/kaminari/_page.html.erb
@@ -1,6 +1,6 @@
 <% if page.current? %>
   <li class='active'>
-    <%= content_tag :a, page, remote: remote, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil)) %>
+    <%= content_tag :a, page, data: { remote: remote }, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil)) %>
   </li>
 <% else %>
   <li>

--- a/bootstrap2/app/views/kaminari/_page.html.haml
+++ b/bootstrap2/app/views/kaminari/_page.html.haml
@@ -1,6 +1,6 @@
 - if page.current?
   %li.active
-    = content_tag :a, page, remote: remote, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil))
+    = content_tag :a, page, data: { remote: remote }, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil))
 - else
   %li
     = link_to page, url, remote: remote, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil))

--- a/bootstrap3/app/views/kaminari/_page.html.erb
+++ b/bootstrap3/app/views/kaminari/_page.html.erb
@@ -1,6 +1,6 @@
 <% if page.current? %>
   <li class='active'>
-    <%= content_tag :a, page, remote: remote, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil)) %>
+    <%= content_tag :a, page, data: { remote: remote }, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil)) %>
   </li>
 <% else %>
   <li>

--- a/bootstrap3/app/views/kaminari/_page.html.haml
+++ b/bootstrap3/app/views/kaminari/_page.html.haml
@@ -1,6 +1,6 @@
 - if page.current?
   %li.active
-    = content_tag :a, page, remote: remote, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil))
+    = content_tag :a, page, data: { remote: remote }, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil))
 - else
   %li
     = link_to page, url, remote: remote, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil))

--- a/bootstrap4/app/views/kaminari/_page.html.erb
+++ b/bootstrap4/app/views/kaminari/_page.html.erb
@@ -1,6 +1,6 @@
 <% if page.current? %>
   <li class="page-item active">
-    <%= content_tag :a, page, remote: remote, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil)), class: 'page-link' %>
+    <%= content_tag :a, page, data: { remote: remote }, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil)), class: 'page-link' %>
   </li>
 <% else %>
   <li class="page-item">

--- a/bootstrap4/app/views/kaminari/_page.html.haml
+++ b/bootstrap4/app/views/kaminari/_page.html.haml
@@ -1,6 +1,6 @@
 - if page.current?
   %li.page-item.active
-    = content_tag :a, page, remote: remote, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil)), class: 'page-link'
+    = content_tag :a, page, data: { remote: remote }, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil)), class: 'page-link'
 - else
   %li.page-item
     = link_to page, url, remote: remote, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil)), class: 'page-link'

--- a/bootstrap4/app/views/kaminari/_page.html.slim
+++ b/bootstrap4/app/views/kaminari/_page.html.slim
@@ -1,6 +1,6 @@
 - if page.current?
   li.page-item.active
-    = content_tag :a, page, remote: remote, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil)), class: 'page-link'
+    = content_tag :a, page, data: { remote: remote }, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil)), class: 'page-link'
 - else
   li.page-item
     = link_to page, url, remote: remote, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil)), class: 'page-link'


### PR DESCRIPTION
Hello! This PR fixes a tiny issue on the bootstrap themed `_page.html.*` partial templates with how `content_tag` differs from `link_to` with regards to passing in `remote: remote`.

By creating an anchor tag  using `content_tag :a,  remote: remote, ...` this actually generates the following html with a "remote=" attribute like so:

```html
<a remote="false">1</a>
```

Which is technically not a valid html attribute for the anchor tag. Also probably not what we intended as we wanted a data-remote attr instead.

Instead if we just use `link_to` over a `content_tag` this gets our desired behaviour we want:

```html
<a data-remote="false">1</a>
```

(looks like bootstrap 2/3 slim templates already do something very similar to my change so didn't include these)