### PR TITLE
Use page.rel helper from kaminari instead of complex conditional logic

### DIFF
--- a/bootstrap2/app/views/kaminari/_page.html.erb
+++ b/bootstrap2/app/views/kaminari/_page.html.erb
@@ -1,9 +1,9 @@
 <% if page.current? %>
   <li class='active'>
-    <%= content_tag :a, page, data: { remote: remote }, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil)) %>
+    <%= content_tag :a, page, data: { remote: remote }, rel: page.rel %>
   </li>
 <% else %>
   <li>
-    <%= link_to page, url, remote: remote, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil)) %>
+    <%= link_to page, url, remote: remote, rel: page.rel %>
   </li>
 <% end %>

--- a/bootstrap2/app/views/kaminari/_page.html.haml
+++ b/bootstrap2/app/views/kaminari/_page.html.haml
@@ -1,6 +1,6 @@
 - if page.current?
   %li.active
-    = content_tag :a, page, data: { remote: remote }, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil))
+    = content_tag :a, page, data: { remote: remote }, rel: page.rel
 - else
   %li
-    = link_to page, url, remote: remote, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil))
+    = link_to page, url, remote: remote, rel: page.rel

--- a/bootstrap2/app/views/kaminari/_page.html.slim
+++ b/bootstrap2/app/views/kaminari/_page.html.slim
@@ -1,2 +1,2 @@
 li class="#{'active' if page.current?}"
-  = link_to page, page.current? ? '#' : url, {:remote => remote, :rel => page.next? ? 'next' : page.prev? ? 'prev' : nil}
+  = link_to page, page.current? ? '#' : url, {:remote => remote, :rel => page.rel}

--- a/bootstrap3/app/views/kaminari/_page.html.erb
+++ b/bootstrap3/app/views/kaminari/_page.html.erb
@@ -1,9 +1,9 @@
 <% if page.current? %>
   <li class='active'>
-    <%= content_tag :a, page, data: { remote: remote }, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil)) %>
+    <%= content_tag :a, page, data: { remote: remote }, rel: page.rel %>
   </li>
 <% else %>
   <li>
-    <%= link_to page, url, remote: remote, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil)) %>
+    <%= link_to page, url, remote: remote, rel: page.rel %>
   </li>
 <% end %>

--- a/bootstrap3/app/views/kaminari/_page.html.haml
+++ b/bootstrap3/app/views/kaminari/_page.html.haml
@@ -1,6 +1,6 @@
 - if page.current?
   %li.active
-    = content_tag :a, page, data: { remote: remote }, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil))
+    = content_tag :a, page, data: { remote: remote }, rel: page.rel
 - else
   %li
-    = link_to page, url, remote: remote, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil))
+    = link_to page, url, remote: remote, rel: page.rel

--- a/bootstrap3/app/views/kaminari/_page.html.slim
+++ b/bootstrap3/app/views/kaminari/_page.html.slim
@@ -1,3 +1,3 @@
 li class="#{'active' if page.current?}"
   = link_to page, page.current? ? '#' : url,
-    remote: remote, rel: page.next? ? 'next' : page.prev? ? 'prev' : nil
+    remote: remote, rel: page.rel

--- a/bootstrap4/app/views/kaminari/_page.html.erb
+++ b/bootstrap4/app/views/kaminari/_page.html.erb
@@ -1,9 +1,9 @@
 <% if page.current? %>
   <li class="page-item active">
-    <%= content_tag :a, page, data: { remote: remote }, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil)), class: 'page-link' %>
+    <%= content_tag :a, page, data: { remote: remote }, rel: page.rel, class: 'page-link' %>
   </li>
 <% else %>
   <li class="page-item">
-    <%= link_to page, url, remote: remote, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil)), class: 'page-link' %>
+    <%= link_to page, url, remote: remote, rel: page.rel, class: 'page-link' %>
   </li>
 <% end %>

--- a/bootstrap4/app/views/kaminari/_page.html.haml
+++ b/bootstrap4/app/views/kaminari/_page.html.haml
@@ -1,6 +1,6 @@
 - if page.current?
   %li.page-item.active
-    = content_tag :a, page, data: { remote: remote }, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil)), class: 'page-link'
+    = content_tag :a, page, data: { remote: remote }, rel: page.rel, class: 'page-link'
 - else
   %li.page-item
-    = link_to page, url, remote: remote, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil)), class: 'page-link'
+    = link_to page, url, remote: remote, rel: page.rel, class: 'page-link'

--- a/bootstrap4/app/views/kaminari/_page.html.slim
+++ b/bootstrap4/app/views/kaminari/_page.html.slim
@@ -1,6 +1,6 @@
 - if page.current?
   li.page-item.active
-    = content_tag :a, page, data: { remote: remote }, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil)), class: 'page-link'
+    = content_tag :a, page, data: { remote: remote }, rel: page.rel, class: 'page-link'
 - else
   li.page-item
-    = link_to page, url, remote: remote, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil)), class: 'page-link'
+    = link_to page, url, remote: remote, rel: page.rel, class: 'page-link'

--- a/bourbon/app/views/kaminari/_page.erb
+++ b/bourbon/app/views/kaminari/_page.erb
@@ -2,6 +2,6 @@
   <% if page.current? %>
     <%= link_to page, "#" %>
   <% else %>
-    <%= link_to_unless page.current?, page, url, {:remote => remote, :rel => page.next? ? 'next' : page.prev? ? 'prev' : nil} %>
+    <%= link_to_unless page.current?, page, url, {:remote => remote, :rel => page.rel} %>
   <% end %>
 </li>

--- a/bourbon/app/views/kaminari/_page.html.haml
+++ b/bourbon/app/views/kaminari/_page.html.haml
@@ -2,4 +2,4 @@
   - if page.current?
     = link_to page, "#"
   - else
-    = link_to_unless page.current?, page, url, {:remote => remote, :rel => page.next? ? 'next' : page.prev? ? 'prev' : nil}
+    = link_to_unless page.current?, page, url, {:remote => remote, :rel => page.rel}

--- a/bourbon/app/views/kaminari/_page.html.slim
+++ b/bourbon/app/views/kaminari/_page.html.slim
@@ -2,4 +2,4 @@ li class="page#{' current' if page.current?}"
   - if page.current?
     = link_to page, "#"
   - else
-    = link_to_unless page.current?, page, url, remote: remote, rel: (page.next? ? 'next' : page.prev? ? 'prev' : nil)
+    = link_to_unless page.current?, page, url, remote: remote, rel: page.rel

--- a/foundation/app/views/kaminari/_page.html.erb
+++ b/foundation/app/views/kaminari/_page.html.erb
@@ -2,6 +2,6 @@
   <% if page.current? %>
     <%= page %>
   <% else %>
-    <%= link_to page, url, {:remote => remote, :rel => page.next? ? 'next' : page.prev? ? 'prev' : nil} %>
+    <%= link_to page, url, {:remote => remote, :rel => page.rel} %>
   <% end %>
 </li>

--- a/foundation/app/views/kaminari/_page.html.haml
+++ b/foundation/app/views/kaminari/_page.html.haml
@@ -2,4 +2,4 @@
   - if page.current?
     = page
   - else
-    = link_to page, url, {:remote => remote, :rel => page.next? ? 'next' : page.prev? ? 'prev' : nil}
+    = link_to page, url, {:remote => remote, :rel => page.rel}

--- a/foundation/app/views/kaminari/_page.html.slim
+++ b/foundation/app/views/kaminari/_page.html.slim
@@ -2,4 +2,4 @@ li class="#{'current' if page.current?}"
   - if page.current?
     = page
   - else
-    = link_to page, url, {:remote => remote, :rel => page.next? ? 'next' : page.prev? ? 'prev' : nil}
+    = link_to page, url, {:remote => remote, :rel => page.rel}

--- a/foundation5/app/views/kaminari/_page.html.erb
+++ b/foundation5/app/views/kaminari/_page.html.erb
@@ -1,3 +1,3 @@
 <li class="<%= 'current' if page.current? %>">
-  <%= link_to page, page.current? ? '#' : url, {:remote => remote, :rel => page.next? ? 'next' : page.prev? ? 'prev' : nil} %>
+  <%= link_to page, page.current? ? '#' : url, {:remote => remote, :rel => page.rel} %>
 </li>

--- a/foundation5/app/views/kaminari/_page.html.haml
+++ b/foundation5/app/views/kaminari/_page.html.haml
@@ -1,2 +1,2 @@
 %li{class: "#{'current' if page.current?}"}
-  = link_to page, page.current? ? '#' : url, {:remote => remote, :rel => page.next? ? 'next' : page.prev? ? 'prev' : nil}
+  = link_to page, page.current? ? '#' : url, {:remote => remote, :rel => page.rel}

--- a/foundation5/app/views/kaminari/_page.html.slim
+++ b/foundation5/app/views/kaminari/_page.html.slim
@@ -1,4 +1,4 @@
 li{class="#{'current' if page.current?}"}
   = link_to(page, page.current? ? '#' : url,
            { :remote => remote,
-              :rel => page.next? ? 'next' : page.prev? ? 'prev' : nil })
+              :rel => page.rel})

--- a/purecss/app/views/kaminari/_page.html.erb
+++ b/purecss/app/views/kaminari/_page.html.erb
@@ -1,3 +1,3 @@
 <li class="pure-u-1-24">
-  <%= link_to page, url, {:class => "pure-button#{' pure-button-active' if page.current?}", :remote => remote, :rel => page.next? ? 'next' : page.prev? ? 'prev' : nil} %>
+  <%= link_to page, url, {:class => "pure-button#{' pure-button-active' if page.current?}", :remote => remote, :rel => page.rel} %>
 </li>

--- a/purecss/app/views/kaminari/_page.html.haml
+++ b/purecss/app/views/kaminari/_page.html.haml
@@ -1,2 +1,2 @@
 %li.pure-u-1-24
-  = link_to page, url, {:class => "pure-button#{' pure-button-active' if page.current?}", :remote => remote, :rel => page.next? ? 'next' : page.prev? ? 'prev' : nil}
+  = link_to page, url, {:class => "pure-button#{' pure-button-active' if page.current?}", :remote => remote, :rel => page.rel}

--- a/purecss/app/views/kaminari/_page.html.slim
+++ b/purecss/app/views/kaminari/_page.html.slim
@@ -1,2 +1,2 @@
 li.pure-u-1-24
-  = link_to page, url, {:class => "pure-button#{' pure-button-active' if page.current?}", :remote => remote, :rel => page.next? ? 'next' : page.prev? ? 'prev' : nil}
+  = link_to page, url, {:class => "pure-button#{' pure-button-active' if page.current?}", :remote => remote, :rel => page.rel}


### PR DESCRIPTION
I noticed in the page partial for a few themes, we can replace some of these conditionals we have for calculating the `rel` by simply deferring to the [rel pagination helper in kaminari instead](https://github.com/kaminari/kaminari/blob/c5186f5d9b7f23299d115408e62047447fd3189d/kaminari-core/lib/kaminari/helpers/paginator.rb#L124-L131) which does the exact same logic.

This makes these partials much cleaner and more aligned with the [page partial that comes from kaminari itself](https://github.com/kaminari/kaminari/blob/9e9ac3b7516b409a4aed1ce1bc6c5e90108c9511/kaminari-core/app/views/kaminari/_page.html.erb#L11).
